### PR TITLE
Credhub encryption key secret, document credhub disaster recovery

### DIFF
--- a/DISASTER_RECOVERY.md
+++ b/DISASTER_RECOVERY.md
@@ -39,9 +39,7 @@ Once both secrets have been modified, delete the credhub pod for the changes to 
 
 ## SQL users password update
 
-There is an issue with [configconnector](https://cloud.google.com/config-connector/docs/overview), in a situation
-where concourse is redeployed from scratch, SQL user passwords are not updated and pods cannot connect to their databases.
-In such situation update the passwords by running the script below:
+There is an issue with [Config Connector](https://cloud.google.com/config-connector/docs/overview), when concourse/uaa/credhub are redeployed from scratch, SQL user passwords are not updated and pods cannot connect to their databases. In such situation update the passwords by running the script below:
 ```
 for user in concourse credhub uaa; do \
   pass=$(kubectl get secret "$user-postgresql-password" -o json | jq -r .data.password | base64 --decode); \

--- a/DISASTER_RECOVERY.md
+++ b/DISASTER_RECOVERY.md
@@ -1,0 +1,50 @@
+# Disaster recovery
+
+Credhub encrypts secrets before storing them in a database.
+In case of a DR situation, credhub encryption key has to restored from GCP Secret Manager before credhub can read data from its database. See [README](./README.md) for more details about preserving the credhub encryption key in GCP.
+
+## Restore Credhub encryption key from Google Secrets
+
+Credhub encryption key is configured in two places:
+- credhub-encryption-key secret
+- credhub-config secret
+
+### credhub-encryption-key
+
+```
+enc_key=$(gcloud secrets versions access 1 --secret credhub-encryption-key | base64)
+kubectl patch secret credhub-encryption-key -p="{\"data\":{\"password\": \"$enc_key\"}}"
+```
+
+### credhub-config
+
+Get the original config yaml and save it to a temp file:
+```
+  kubectl get secret credhub-config -o json | jq -r '.data["application.yml"]' | base64 --decode > tmp.yml
+```
+
+Replace encryption.providers[0].keys[0].encryption_password in tmp.yml to match the one from Google Secrets:
+```
+gcloud secrets versions access 1 --secret credhub-encryption-key
+```
+
+Obtain base64 encoded contents of the credhub-config secret and modify the secret:
+```
+cat tmp.yml | base64 | pbcopy
+kubectl edit secret credhub-config
+```
+
+Paste the contents from the clipboard and save the changes.
+Once both secrets have been modified, delete the credhub pod for the changes to propagate. Verify newly started credhub pod can read its database by tailing the log.
+
+## SQL users password update
+
+There is an issue with [configconnector](https://cloud.google.com/config-connector/docs/overview), in a situation
+where concourse is redeployed from scratch, SQL user passwords are not updated and pods cannot connect to their databases.
+In such situation update the passwords by running the script below:
+```
+for user in concourse credhub uaa; do \
+  pass=$(kubectl get secret "$user-postgresql-password" -o json | jq -r .data.password | base64 --decode); \
+  gcloud sql users set-password "$user" -i concourse --password="$pass";\
+done
+```

--- a/README.md
+++ b/README.md
@@ -129,6 +129,23 @@ cnrm-system@${PROJECT_ID}.iam.gserviceaccount.com \
   --role="roles/iam.workloadIdentityUser"
 ```
 
+#### Deploy the project to the cluster
+```
+./bin/sync
+./bin/build
+./bin/deploy
+```
+
+#### Store credhub encryption key in Google Secrets
+
+Once deployed, we have to save credhub encryption key to Google Secrets in case of a disaster situation.
+This is to be done only on first deployment, see [DISASTER_RECOVERY](./DISASTER_RECOVERY.md) for recovery details.
+
+```
+gcloud secrets create credhub-encryption-key
+kubectl get secret credhub-encryption-key -o json | jq -r .data.password | base64 --decode | gcloud secrets versions add credhub-encryption-key --data-file=-
+```
+
 # TODO document creating the concourse gke cluster using the gcloud cli
 
 - sql database uses an public ip address for sql proxy only. This should also be possible by using a private ip. See https://console.cloud.google.com/sql/instances/concourse/edit?orgonly=true&project=cloud-foundry-310819&supportedpurview=organizationId

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ cnrm-system@${PROJECT_ID}.iam.gserviceaccount.com \
 #### Store credhub encryption key in Google Secrets
 
 Once deployed, we have to save credhub encryption key to Google Secrets in case of a disaster situation.
-This is to be done only on first deployment, see [DISASTER_RECOVERY](./DISASTER_RECOVERY.md) for recovery details.
+This is to be done only on first deployment, see [docs/disaster_recovery](./docs/disaster_recovery.md) for recovery details.
 
 ```
 gcloud secrets create credhub-encryption-key

--- a/config/credhub/credhub.yml
+++ b/config/credhub/credhub.yml
@@ -72,7 +72,7 @@ spec:
         - name: ENCRYPTION_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: encryption-key
+              name: credhub-encryption-key
               key: password
         #@overlay/match by=overlay.subset({"name": "SUBJECT_ALTERNATIVE_NAMES"})
         #@overlay/replace

--- a/config/credhub/secrets.yml
+++ b/config/credhub/secrets.yml
@@ -69,7 +69,7 @@ spec:
           name: "credhub-truststore-key"
           key: "password"
         encryptionPassword:
-          name: "encryption-key"
+          name: "credhub-encryption-key"
           key: "password"
 
 ---
@@ -91,6 +91,16 @@ metadata:
 spec:
   type: password
   secretName: credhub-truststore-key
+
+---
+apiVersion: quarks.cloudfoundry.org/v1alpha1
+kind: QuarksSecret
+metadata:
+  name: credhub-encryption-key
+  namespace: concourse
+spec:
+  type: password
+  secretName: credhub-encryption-key
 
 
 ---

--- a/config/uaa/secrets/encryption_keys.yml
+++ b/config/uaa/secrets/encryption_keys.yml
@@ -16,18 +16,18 @@ spec:
             active_key_label: default_encryption_key
             encryption_keys:
             - label: default_encryption_key
-              passphrase: '{{.Values.client_credentials}}'
+              passphrase: '{{.Values.uaa_encryption_key}}'
       values:
-        client_credentials:
-          name: "encryption-key"
+        uaa_encryption_key:
+          name: "uaa-encryption-key"
           key: "password"
 
 ---
 apiVersion: quarks.cloudfoundry.org/v1alpha1
 kind: QuarksSecret
 metadata:
-  name: encryption-key
+  name: uaa-encryption-key
   namespace: concourse
 spec:
   type: password
-  secretName: encryption-key
+  secretName: uaa-encryption-key

--- a/docs/disaster_recovery.md
+++ b/docs/disaster_recovery.md
@@ -1,7 +1,7 @@
 # Disaster recovery
 
 Credhub encrypts secrets before storing them in a database.
-In case of a DR situation, credhub encryption key has to restored from GCP Secret Manager before credhub can read data from its database. See [README](./README.md) for more details about preserving the credhub encryption key in GCP.
+In case of a DR situation, credhub encryption key has to restored from GCP Secret Manager before credhub can read data from its database. See [README](../README.md) for more details about preserving the credhub encryption key in GCP.
 
 ## Restore Credhub encryption key from Google Secrets
 


### PR DESCRIPTION
#24 

Separate secret for credhub encryption key rather than using one from uaa. 
Readme for disaster recovery steps.