### PR TITLE
Worker pod tolerations

### DIFF
--- a/build/concourse/values.yml
+++ b/build/concourse/values.yml
@@ -52,6 +52,16 @@ web:
       type: LoadBalancer
       loadBalancerIP: 34.90.62.88
 worker:
+  additionalAffinities:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 50
+          preference:
+            matchExpressions:
+              - key: cloud.google.com/gke-nodepool
+                operator: In
+                values:
+                  - "concourse-workers"
   tolerations:
     - key: "workers"
       operator: "Equal"

--- a/build/concourse/values.yml
+++ b/build/concourse/values.yml
@@ -51,3 +51,9 @@ web:
     api:
       type: LoadBalancer
       loadBalancerIP: 34.90.62.88
+worker:
+  tolerations:
+    - key: "workers"
+      operator: "Equal"
+      value: "true"
+      effect: "NoSchedule"

--- a/config/concourse/_ytt_lib/concourse/rendered.yml
+++ b/config/concourse/_ytt_lib/concourse/rendered.yml
@@ -345,6 +345,11 @@ spec:
         release: concourse
     spec:
       serviceAccountName: default
+      tolerations:
+      - effect: NoSchedule
+        key: workers
+        operator: Equal
+        value: "true"
       terminationGracePeriodSeconds: 60
       initContainers:
       - name: concourse-worker-init-rm

--- a/config/concourse/_ytt_lib/concourse/rendered.yml
+++ b/config/concourse/_ytt_lib/concourse/rendered.yml
@@ -455,6 +455,15 @@ spec:
           mountPath: /pre-stop-hook.sh
           subPath: pre-stop-hook.sh
       affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: cloud.google.com/gke-nodepool
+                operator: In
+                values:
+                - concourse-workers
+            weight: 50
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
           - weight: 100


### PR DESCRIPTION
#21

Configures tolerations for preemptible worker nodes. Also adding node affinity to attract worker pods to worker nodes with the weight of 50 out 100