### PR TITLE
Update to stabilise autoscaler acceptance tests

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -80,7 +80,8 @@ gcloud compute routers nats create nat-config \
     --router nat-router \
     --nat-all-subnet-ip-ranges \
     --auto-allocate-nat-external-ips \
-    --min-ports-per-vm=512
+    --min-ports-per-vm=4095 \
+    --tcp-established-idle-timeout=60 
 
 # setup firewall to connect from gke to internal instance vms
 # https://cloud.google.com/kubernetes-engine/docs/troubleshooting#autofirewall


### PR DESCRIPTION
- updated the number of ports to vms to 4095 so that the K8s node does not overflow the limits during the autoscaler load tests.
- reduced the tcp idle timout from 20 mins to 1 min in order to reduce the port usage.