### PR TITLE
Replace deprecated --enable-stackdriver-kubernetes parameter

### DIFF
--- a/bin/init
+++ b/bin/init
@@ -42,7 +42,8 @@ gcloud container clusters create $CLUSTER_NAME \
   --release-channel regular \
   --addons ConfigConnector \
   --workload-pool=${PROJECT_ID}.svc.id.goog \
-  --enable-stackdriver-kubernetes \
+  --logging=SYSTEM,WORKLOAD \
+  --monitoring=SYSTEM \
   --region europe-west4-a \
   --num-nodes=1 \
   --min-nodes=1 \


### PR DESCRIPTION
* see table with new parameters: https://cloud.google.com/stackdriver/docs/solutions/gke/installing#deprecated_configuration_parameters

Signed-off-by: Aftab Alam <81828613+iaftab-alam@users.noreply.github.com@sap.com>